### PR TITLE
feat: update delay access control

### DIFF
--- a/contracts/BridgeExecutorBase.sol
+++ b/contracts/BridgeExecutorBase.sol
@@ -8,13 +8,12 @@ import './interfaces/IBridgeExecutor.sol';
 abstract contract BridgeExecutorBase is IBridgeExecutor {
   using SafeMath for uint256;
 
+  uint256 private _delay;
   uint256 private _gracePeriod;
   uint256 private _minimumDelay;
   uint256 private _maximumDelay;
-
-  uint256 private _actionsSetCounter;
   address private _guardian;
-  uint256 private _delay;
+  uint256 private _actionsSetCounter;
 
   mapping(uint256 => ActionsSet) private _actionsSets;
   mapping(bytes32 => bool) private _queuedActions;
@@ -42,10 +41,7 @@ abstract contract BridgeExecutorBase is IBridgeExecutor {
     _gracePeriod = gracePeriod;
     _minimumDelay = minimumDelay;
     _maximumDelay = maximumDelay;
-
     _guardian = guardian;
-
-    emit NewDelay(delay);
   }
 
   /**
@@ -97,17 +93,6 @@ abstract contract BridgeExecutorBase is IBridgeExecutor {
   }
 
   /**
-   * @dev Set the delay
-   * @param delay delay between queue and execution of an ActionsSet
-   **/
-  function setDelay(uint256 delay) public override onlyGuardian {
-    _validateDelay(delay);
-    _delay = delay;
-
-    emit NewDelay(delay);
-  }
-
-  /**
    * @dev Get the ActionsSet by Id
    * @param actionsSetId id of the ActionsSet
    * @return the ActionsSet requested
@@ -154,6 +139,16 @@ abstract contract BridgeExecutorBase is IBridgeExecutor {
    * @dev Receive Funds if necessary for delegate calls
    **/
   function receiveFunds() external payable {}
+
+  /**
+   * @dev Set the delay
+   * @param delay delay between queue and execution of an ActionsSet
+   **/
+  function updateDelay(uint256 delay) external override onlyThis {
+    _validateDelay(delay);
+    emit DelayUpdate(_delay, delay);
+    _delay = delay;
+  }
 
   /**
    * @dev Set the grace period - time before a queued action will expire

--- a/contracts/interfaces/IBridgeExecutor.sol
+++ b/contracts/interfaces/IBridgeExecutor.sol
@@ -64,9 +64,10 @@ interface IBridgeExecutor {
 
   /**
    * @dev emitted when a new delay (between queueing and execution) is set
-   * @param delay new delay
+   * @param previousDelay previous delay
+   * @param newDelay new delay
    **/
-  event NewDelay(uint256 delay);
+  event DelayUpdate(uint256 previousDelay, uint256 newDelay);
 
   /**
    * @dev emitted when a GracePeriod is updated
@@ -102,12 +103,6 @@ interface IBridgeExecutor {
   function cancel(uint256 actionsSetId) external;
 
   /**
-   * @dev Set the delay
-   * @param delay delay between queue and execution of an ActionSet
-   **/
-  function setDelay(uint256 delay) external;
-
-  /**
    * @dev Get the ActionsSet by Id
    * @param actionsSetId id of the ActionsSet
    * @return the ActionsSet requested
@@ -128,6 +123,12 @@ interface IBridgeExecutor {
    * @return true if underlying action of actionHash is queued
    **/
   function isActionQueued(bytes32 actionHash) external view returns (bool);
+
+  /**
+   * @dev Update the delay
+   * @param delay delay between queue and execution of an ActionSet
+   **/
+  function updateDelay(uint256 delay) external;
 
   /**
    * @dev Set the grace period - time before a queued action will expire

--- a/test/helpers/bridge-helpers.ts
+++ b/test/helpers/bridge-helpers.ts
@@ -492,6 +492,41 @@ export const createBridgeTest13 = async (
   return proposalActions;
 };
 
+export const createBridgeTest14 = async (
+  dummyUint: number,
+  testEnv: TestEnv
+): Promise<ProposalActions> => {
+  const { ethers } = DRE;
+  const { polygonBridgeExecutor } = testEnv;
+  const proposalActions = new ProposalActions();
+
+  // push the first transaction fields into action arrays
+  const encodedAddress = ethers.utils.defaultAbiCoder.encode(['uint256'], [dummyUint]);
+  proposalActions.targets.push(polygonBridgeExecutor.address);
+  proposalActions.values.push(BigNumber.from(0));
+  proposalActions.signatures.push('updateDelay(uint256)');
+  proposalActions.calldatas.push(encodedAddress);
+  proposalActions.withDelegatecalls.push(false);
+
+  proposalActions.encodedActions = ethers.utils.defaultAbiCoder.encode(
+    ['address[]', 'uint256[]', 'string[]', 'bytes[]', 'bool[]'],
+    [
+      proposalActions.targets,
+      proposalActions.values,
+      proposalActions.signatures,
+      proposalActions.calldatas,
+      proposalActions.withDelegatecalls,
+    ]
+  );
+
+  proposalActions.encodedRootCalldata = ethers.utils.defaultAbiCoder.encode(
+    ['address', 'bytes'],
+    [polygonBridgeExecutor.address, proposalActions.encodedActions]
+  );
+
+  return proposalActions;
+};
+
 export const createArbitrumBridgeTest = async (
   dummyUint: number,
   dummyString: string,


### PR DESCRIPTION
Update the delay variable to be controlled by the aave ethereum governance rather than just the guardian.

If it is only controlled by the guardian a guardian in bad-faith could set the delay to infinity.