### PR TITLE
feat: add getters

### DIFF
--- a/contracts/ArbitrumBridgeExecutor.sol
+++ b/contracts/ArbitrumBridgeExecutor.sol
@@ -54,4 +54,12 @@ contract ArbitrumBridgeExecutor is BridgeExecutorBase {
     emit EthereumGovernanceExecutorUpdate(_ethereumGovernanceExecutor, ethereumGovernanceExecutor);
     _ethereumGovernanceExecutor = ethereumGovernanceExecutor;
   }
+
+  /**
+   * @dev get the current address of ethereumGovernanceExecutor
+   * @return ethereumGovernanceExecutor the address of the Ethereum Governance Executor contract
+   **/
+  function getEthereumGovernanceExecutor() external view returns (address) {
+    return _ethereumGovernanceExecutor;
+  }
 }

--- a/contracts/PolygonBridgeExecutor.sol
+++ b/contracts/PolygonBridgeExecutor.sol
@@ -74,4 +74,20 @@ contract PolygonBridgeExecutor is BridgeExecutorBase, IFxMessageProcessor {
     emit FxChildUpdate(_fxChild, fxChild);
     _fxChild = fxChild;
   }
+
+  /**
+   * @dev Get the address currently stored as fxRootSender
+   * @return fxRootSender contract originating a cross-chain tranasaction - likely the aave governance executor
+   **/
+  function getFxRootSender() external view returns (address) {
+    return _fxRootSender;
+  }
+
+  /**
+   * @dev Get the address currently stored as fxChild
+   * @return fxChild the address of the contract used to foward cross-chain transactions on Polygon
+   **/
+  function getFxChild() external view returns (address) {
+    return _fxChild;
+  }
 }

--- a/test/crosschain-bridges.ts
+++ b/test/crosschain-bridges.ts
@@ -154,7 +154,7 @@ makeSuite('Crosschain bridge tests', setupTestEnvironment, (testEnv: TestEnv) =>
      * Create Proposal Actions 10 -
      * Update FxChild - PolygonBridgeExecutor
      */
-    const proposal10Actions = await createBridgeTest10(aaveWhale2.address, testEnv);
+    const proposal10Actions = await createBridgeTest10(aaveWhale3.address, testEnv);
     testEnv.proposalActions.push(proposal10Actions);
 
     /**
@@ -809,12 +809,12 @@ makeSuite('Crosschain bridge tests', setupTestEnvironment, (testEnv: TestEnv) =>
         );
     });
     it('Execute Action Set 6 - updateFxChild', async () => {
-      const { polygonBridgeExecutor, fxChild, aaveWhale2 } = testEnv;
+      const { polygonBridgeExecutor, fxChild, aaveWhale3 } = testEnv;
       await expect(polygonBridgeExecutor.execute(6))
         .to.emit(polygonBridgeExecutor, 'FxChildUpdate')
         .withArgs(
           DRE.ethers.utils.getAddress(fxChild.address),
-          DRE.ethers.utils.getAddress(aaveWhale2.address)
+          DRE.ethers.utils.getAddress(aaveWhale3.address)
         );
     });
     it('Execute Action Set 7 - updateMinDelay', async () => {
@@ -855,6 +855,28 @@ makeSuite('Crosschain bridge tests', setupTestEnvironment, (testEnv: TestEnv) =>
           DRE.ethers.utils.getAddress(shortExecutor.address),
           DRE.ethers.utils.getAddress(aaveWhale2.address)
         );
+    });
+  });
+  describe('PolygonBridgeExecutor Getters - FxRootSender, FxChild', async function () {
+    it('Get FxRootSender', async () => {
+      const { polygonBridgeExecutor, aaveWhale2 } = testEnv;
+      expect(await polygonBridgeExecutor.getFxRootSender()).to.be.equal(
+        DRE.ethers.utils.getAddress(aaveWhale2.address)
+      );
+    });
+    it('Get FxChild', async () => {
+      const { polygonBridgeExecutor, aaveWhale3 } = testEnv;
+      expect(await polygonBridgeExecutor.getFxChild()).to.be.equal(
+        DRE.ethers.utils.getAddress(aaveWhale3.address)
+      );
+    });
+  });
+  describe('ArbitrumBridgeExecutor Getters - EthereumGovernanceExecutor', async function () {
+    it('Get EthereumGovernanceExecutor', async () => {
+      const { arbitrumBridgeExecutor, aaveWhale2 } = testEnv;
+      expect(await arbitrumBridgeExecutor.getEthereumGovernanceExecutor()).to.be.equal(
+        DRE.ethers.utils.getAddress(aaveWhale2.address)
+      );
     });
   });
   describe('Cancel Actions - Aave Polygon Governance', async function () {


### PR DESCRIPTION
Adding getters for the following variables:

PolygonBridgeExecutor:
_fxRootSender
_fxChild

ArbitrumBridgeExecutor:
_ethereumGovernanceExecutor

Added tests to cover these changes. Updated the scenario to update the `_fxRootSender` to aaveWhale2.address and `_fxChild` to aaveWhale3.address to reduce the likelyhood of a test incorrectly passing by using the same address.