### PR TITLE
fix: remove @inheritdoc from function not in interface

### DIFF
--- a/contracts/BridgeExecutorBase.sol
+++ b/contracts/BridgeExecutorBase.sol
@@ -119,7 +119,6 @@ abstract contract BridgeExecutorBase is IBridgeExecutor {
     return _queuedActions[actionHash];
   }
 
-  /// @inheritdoc IBridgeExecutor
   function receiveFunds() external payable {}
 
   /// @inheritdoc IBridgeExecutor


### PR DESCRIPTION
`function receiveFunds() external payable {}`

Is not included in the `IBridgeExecutor` interface.

The function is self explanatory and therefore does not require a comment or description.